### PR TITLE
feat: チャット画面の実装

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import React, { useState, useEffect, useRef } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Send, User, Sparkles, LogOut, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+// 型定義
+type Message = {
+  role: "user" | "model";
+  content: string;
+};
+
+type Big5 = {
+  o: number;
+  c: number;
+  e: number;
+  a: number;
+  n: number;
+};
+
+// -----------------------------------------------------------------------------
+// モック API 関数 (本来はサーバーサイド実装)
+// -----------------------------------------------------------------------------
+
+// 会話APIのモック
+const mockChatApi = async (
+  message: string,
+  situation: string,
+  big5: Big5
+): Promise<string> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      // 簡易的な性格反映ロジック（デモ用）
+      let prefix = "";
+      if (big5.e > 0.6) prefix += "（元気よく）";
+      if (big5.n > 0.6) prefix += "（少し心配そうに）";
+      if (big5.o > 0.6) prefix += "なるほど、興味深いですね！";
+      
+      const responses = [
+        `その件について、${situation}の観点から考えるとどう思いますか？`,
+        "それは新しい発見ですね。詳しく教えてください。",
+        "ふむふむ、それで？",
+        `今の言葉、すごくあなたらしい響きがしました。`,
+      ];
+      
+      const randomRes = responses[Math.floor(Math.random() * responses.length)];
+      resolve(`${prefix} ${message}ですね。${randomRes}`);
+    }, 1000); // 1秒の遅延
+  });
+};
+
+// 分析APIのモック
+const mockAnalyzeApi = async (messages: Message[]): Promise<{ selfVector: Big5; summary: string }> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        selfVector: {
+          o: Math.random(),
+          c: Math.random(),
+          e: Math.random(),
+          a: Math.random(),
+          n: Math.random(),
+        },
+        summary: "今回の会話から、あなたは非常に論理的でありながら、新しい可能性に対して開かれた姿勢を持っていることが読み取れました。特に後半の問いかけには、自身の内面を深く見つめようとする意志が感じられます。",
+      });
+    }, 2000); // 2秒の遅延
+  });
+};
+
+// -----------------------------------------------------------------------------
+// メインコンポーネント
+// -----------------------------------------------------------------------------
+
+export default function ChatPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // URLパラメータから鏡の設定を取得
+  const situation = searchParams.get("situation") || "未設定のシチュエーション";
+  const mirrorBig5: Big5 = {
+    o: parseFloat(searchParams.get("o") || "0.5"),
+    c: parseFloat(searchParams.get("c") || "0.5"),
+    e: parseFloat(searchParams.get("e") || "0.5"),
+    a: parseFloat(searchParams.get("a") || "0.5"),
+    n: parseFloat(searchParams.get("n") || "0.5"),
+  };
+
+  // State
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [turnCount, setTurnCount] = useState(0);
+
+  const MAX_TURNS = 10;
+
+  // 自動スクロール
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [messages, loading]);
+
+  // 初回メッセージ（オプション：鏡からの挨拶を入れる場合）
+  useEffect(() => {
+    if (messages.length === 0) {
+       // ここで初期メッセージを入れることも可能ですが、
+       // 仕様では「ユーザー送信のたびに...」とあるため、最初は空か、システムメッセージのみとします。
+    }
+  }, []);
+
+  // 送信ハンドラ
+  const handleSend = async () => {
+    if (!input.trim() || loading || analyzing || turnCount >= MAX_TURNS) return;
+
+    const userMsg = input;
+    setInput("");
+    setMessages((prev) => [...prev, { role: "user", content: userMsg }]);
+    setLoading(true);
+
+    try {
+      // 1. AI応答の取得 (Mock)
+      const aiResponse = await mockChatApi(userMsg, situation, mirrorBig5);
+      
+      setMessages((prev) => [...prev, { role: "model", content: aiResponse }]);
+      setTurnCount((prev) => prev + 1);
+
+    } catch (error) {
+      console.error("Chat Error:", error);
+      // エラー処理（トーストなどを出すのが望ましい）
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 終了・分析ハンドラ
+  const handleFinish = async () => {
+    if (messages.length === 0) return; // 会話なしでは終了不可
+    setAnalyzing(true);
+
+    try {
+      // 1. 分析実行 (Mock)
+      const result = await mockAnalyzeApi(messages);
+
+      // 2. レポートページへ遷移 (クエリパラメータで結果を渡す)
+      const query = new URLSearchParams({
+        // 分析結果 (Self)
+        s_o: result.selfVector.o.toString(),
+        s_c: result.selfVector.c.toString(),
+        s_e: result.selfVector.e.toString(),
+        s_a: result.selfVector.a.toString(),
+        s_n: result.selfVector.n.toString(),
+        summary: result.summary,
+        // 鏡の設定 (Resonanceとして保存するため引き継ぐ)
+        r_o: mirrorBig5.o.toString(),
+        r_c: mirrorBig5.c.toString(),
+        r_e: mirrorBig5.e.toString(),
+        r_a: mirrorBig5.a.toString(),
+        r_n: mirrorBig5.n.toString(),
+        situation: situation,
+      });
+
+      router.push(`/report?${query.toString()}`);
+
+    } catch (error) {
+      console.error("Analysis Error:", error);
+      setAnalyzing(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-4rem)] max-w-2xl mx-auto w-full p-4">
+      {/* ヘッダー情報 */}
+      <Card className="mb-4 shadow-sm shrink-0">
+        <CardHeader className="py-4 px-6 flex flex-row items-center justify-between space-y-0">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-10 w-10 border-2 border-primary/20">
+              <AvatarFallback><Sparkles className="h-5 w-5 text-primary" /></AvatarFallback>
+            </Avatar>
+            <div>
+              <h2 className="text-sm font-medium text-muted-foreground">Mirror Situation</h2>
+              <p className="font-bold text-base">{situation}</p>
+            </div>
+          </div>
+          
+          <div className="flex items-center gap-4">
+            <div className="text-right">
+              <span className="text-xs text-muted-foreground">Turn</span>
+              <p className={`font-mono font-bold ${turnCount >= MAX_TURNS ? "text-destructive" : ""}`}>
+                {turnCount} / {MAX_TURNS}
+              </p>
+            </div>
+            
+            {/* 任意終了ボタン */}
+            <Button 
+              variant="outline" 
+              size="sm" 
+              onClick={handleFinish}
+              disabled={analyzing || messages.length === 0}
+              className="hidden sm:flex"
+            >
+              {analyzing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <LogOut className="mr-2 h-4 w-4" />}
+              終了して分析
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      {/* チャットエリア */}
+      <Card className="flex-1 flex flex-col overflow-hidden shadow-sm">
+        <CardContent className="flex-1 p-0 relative">
+          <div 
+            ref={scrollRef} 
+            className="absolute inset-0 overflow-y-auto p-4 space-y-4"
+          >
+            {messages.length === 0 && (
+              <div className="h-full flex flex-col items-center justify-center text-muted-foreground opacity-50 space-y-2">
+                <Sparkles className="h-12 w-12" />
+                <p>新しい自分を見つけましょう</p>
+              </div>
+            )}
+
+            {messages.map((msg, idx) => (
+              <div
+                key={idx}
+                className={`flex gap-3 ${
+                  msg.role === "user" ? "flex-row-reverse" : "flex-row"
+                }`}
+              >
+                <Avatar className="h-8 w-8 mt-1">
+                  {msg.role === "user" ? (
+                    <>
+                      <AvatarImage src="" /> {/* ユーザーアイコンがあれば */}
+                      <AvatarFallback className="bg-slate-200"><User className="h-4 w-4 text-slate-600" /></AvatarFallback>
+                    </>
+                  ) : (
+                    <AvatarFallback className="bg-primary/10"><Sparkles className="h-4 w-4 text-primary" /></AvatarFallback>
+                  )}
+                </Avatar>
+                
+                <div
+                  className={`max-w-[80%] rounded-lg p-3 text-sm leading-relaxed whitespace-pre-wrap ${
+                    msg.role === "user"
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-foreground"
+                  }`}
+                >
+                  {msg.content}
+                </div>
+              </div>
+            ))}
+
+            {loading && (
+              <div className="flex gap-3">
+                <Avatar className="h-8 w-8 mt-1">
+                  <AvatarFallback className="bg-primary/10"><Sparkles className="h-4 w-4 text-primary" /></AvatarFallback>
+                </Avatar>
+                <div className="bg-muted text-foreground rounded-lg p-3 flex items-center">
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                  <span className="text-xs text-muted-foreground">思考中...</span>
+                </div>
+              </div>
+            )}
+            
+            {/* ターン数上限到達時のメッセージ */}
+            {turnCount >= MAX_TURNS && !analyzing && (
+              <div className="text-center py-4 text-sm text-muted-foreground">
+                <p>会話の上限に達しました。</p>
+                <Button variant="link" onClick={handleFinish}>分析結果を見る</Button>
+              </div>
+            )}
+          </div>
+        </CardContent>
+
+        {/* 入力エリア */}
+        <CardFooter className="p-3 bg-card border-t">
+          <form 
+            className="flex w-full gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSend();
+            }}
+          >
+            <Input
+              placeholder={turnCount >= MAX_TURNS ? "会話終了" : "メッセージを入力..."}
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              disabled={loading || analyzing || turnCount >= MAX_TURNS}
+              className="flex-1"
+              autoFocus
+            />
+            {turnCount >= MAX_TURNS ? (
+              <Button 
+                type="button" 
+                onClick={handleFinish} 
+                disabled={analyzing}
+                variant="default" // 目立たせる
+              >
+                {analyzing ? <Loader2 className="h-4 w-4 animate-spin" /> : "分析へ"}
+              </Button>
+            ) : (
+              <Button type="submit" size="icon" disabled={!input.trim() || loading}>
+                <Send className="h-4 w-4" />
+                <span className="sr-only">Send</span>
+              </Button>
+            )}
+          </form>
+        </CardFooter>
+      </Card>
+      
+      {/* モバイル用終了ボタン（ヘッダーに入りきらない場合用） */}
+      <div className="sm:hidden mt-2 flex justify-end">
+        <Button 
+          variant="ghost" 
+          size="sm" 
+          onClick={handleFinish}
+          disabled={analyzing || messages.length === 0}
+          className="text-muted-foreground"
+        >
+          {analyzing ? "分析中..." : "会話を終了して分析結果を見る"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import * as React from "react"
+import { Avatar as AvatarPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Avatar({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Root> & {
+  size?: "default" | "sm" | "lg"
+}) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      className={cn(
+        "group/avatar relative flex size-8 shrink-0 overflow-hidden rounded-full select-none data-[size=lg]:size-10 data-[size=sm]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarImage({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  )
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "bg-muted text-muted-foreground flex size-full items-center justify-center rounded-full text-sm group-data-[size=sm]/avatar:text-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="avatar-badge"
+      className={cn(
+        "bg-primary text-primary-foreground ring-background absolute right-0 bottom-0 z-10 inline-flex items-center justify-center rounded-full ring-2 select-none",
+        "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
+        "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
+        "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group"
+      className={cn(
+        "*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AvatarGroupCount({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="avatar-group-count"
+      className={cn(
+        "bg-muted text-muted-foreground ring-background relative flex size-8 shrink-0 items-center justify-center rounded-full text-sm ring-2 group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Avatar,
+  AvatarImage,
+  AvatarFallback,
+  AvatarBadge,
+  AvatarGroup,
+  AvatarGroupCount,
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "amiro",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/ssr": "^0.8.0",
-        "@supabase/supabase-js": "^2.95.3",
         "@google/generative-ai": "^0.24.1",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
@@ -4372,98 +4370,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@supabase/auth-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
-      "integrity": "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.3.tgz",
-      "integrity": "sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/postgrest-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.3.tgz",
-      "integrity": "sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/realtime-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.3.tgz",
-      "integrity": "sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/ssr": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz",
-      "integrity": "sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.2"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.76.1"
-      }
-    },
-    "node_modules/@supabase/storage-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.3.tgz",
-      "integrity": "sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==",
-      "license": "MIT",
-      "dependencies": {
-        "iceberg-js": "^0.8.1",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/supabase-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
-      "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-js": "2.95.3",
-        "@supabase/functions-js": "2.95.3",
-        "@supabase/postgrest-js": "2.95.3",
-        "@supabase/realtime-js": "2.95.3",
-        "@supabase/storage-js": "2.95.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -6437,12 +6343,6 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@supabase/ssr": "^0.8.0",
-    "@supabase/supabase-js": "^2.95.3",
     "@google/generative-ai": "^0.24.1",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",


### PR DESCRIPTION
## 関連Issue
- Closes #25 

## 概要
選んだAI（鏡）と対話を行うチャット画面のUIおよび、フロントエンド完結での動作ロジックを実装しました。
シチュエーションや性格設定をURLパラメータから受け取り、モックAPIを用いて会話・分析・結果画面への遷移までの一連のフローを確認できるようにしています。

## やったこと
- **チャット画面（`app/(app)/chat/page.tsx`）の新規作成**
  - **UI実装**: メッセージリスト、入力フォーム、ヘッダー（シチュエーション・ターン数表示）を実装。
  - **パラメータ受け取り**: URLクエリパラメータ（`situation`, `o`, `c`, `e`, `a`, `n`）から鏡の設定を読み込むロジックを追加。
  - **モックAPIの実装**: 
    - `mockChatApi`: 性格パラメータ（Big5）に応じて「元気よく」「心配そうに」などの接頭辞が付く擬似的な応答を生成。
    - `mockAnalyzeApi`: 会話終了時にランダムな分析結果と要約を生成。
  - **会話フロー制御**: 
    - 10往復のカウント制限と表示。
    - 任意タイミングでの「終了して分析」機能。
  - **レポート遷移**: 分析完了後、結果（Self）と鏡の設定（Resonance）をクエリパラメータに含めて `/report` へ遷移させる処理。

## 動作確認手順
1. 開発サーバーを起動（`npm run dev` 等）。
2. ブラウザで以下のURL（パラメータ付き）に直接アクセスし、ヘッダーに「深夜のバー」と表示されるか確認。
   > `http://localhost:3000/chat?situation=深夜のバー&o=0.8&c=0.3&e=0.9&a=0.5&n=0.2`
3. メッセージを送信し、AI（モック）から即時返信が来ることを確認（性格パラメータに応じた口調の変化が含まれる場合があります）。
4. 「終了して分析」ボタンをクリック、または10往復会話を行い、`/report` へ遷移することを確認。
   - ※遷移先のURLに `s_o=...` や `summary=...` などのパラメータが付与されていれば成功です。

## 備考・共有事項
- **API連携**: 現在は内部定義したモック関数を使用しています。バックエンドAPI（`/api/ai/chat` 等）の実装完了後に差し替え予定です。
- **遷移先**: レポート画面（`/report`）は未実装のため 404 になりますが、遷移ロジックの確認用として実装しています。
- **ホーム画面連携**: ホーム画面からこのチャット画面へパラメータを渡す処理は本PRには含まれません（別タスクにて対応）。