### PR TITLE
Add POST /api/ai/analyze and Big5/personaSummary prompt

### DIFF
--- a/app/api/ai/analyze/route.ts
+++ b/app/api/ai/analyze/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { analyzeFromMessages } from "@/lib/ai/analyze";
+import type { AnalyzeMessage } from "@/lib/prompts/analyze";
+
+/** POST /api/ai/analyze: 会話ログから selfVector と personaSummary を返す */
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as { messages?: unknown };
+    const messages = body.messages;
+
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return NextResponse.json(
+        { error: "messages must be a non-empty array" },
+        { status: 400 }
+      );
+    }
+
+    const typedMessages: AnalyzeMessage[] = [];
+    for (const m of messages) {
+      if (
+        m &&
+        typeof m === "object" &&
+        "role" in m &&
+        "content" in m &&
+        (m.role === "user" || m.role === "model") &&
+        typeof (m as { content: unknown }).content === "string"
+      ) {
+        typedMessages.push({
+          role: m.role,
+          content: (m as { content: string }).content,
+        });
+      } else {
+        return NextResponse.json(
+          { error: "Each message must have role (user|model) and content (string)" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const result = await analyzeFromMessages(typedMessages);
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[POST /api/ai/analyze]", err);
+    return NextResponse.json(
+      { error: "Analysis failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/ai/analyze.ts
+++ b/lib/ai/analyze.ts
@@ -1,0 +1,103 @@
+/**
+ * 会話ログから selfVector と personaSummary を返す分析ロジック
+ * issue: ai_analyze_self / ai_prompts
+ */
+
+import {
+  type ObjectSchema as GeminiObjectSchema,
+  SchemaType,
+} from "@google/generative-ai";
+import { z } from "zod";
+import { getGeminiClient } from "@/lib/gemini";
+import { GEMINI_MODEL_NAME } from "@/lib/gemini";
+import { buildAnalyzePrompt, type AnalyzeMessage } from "@/lib/prompts/analyze";
+import type { Big5Vector } from "@/lib/types";
+
+const MAX_RETRIES = 2;
+
+/** Gemini 用の JSON 出力スキーマ（selfVector + personaSummary） */
+const analyzeResponseSchema: GeminiObjectSchema = {
+  type: SchemaType.OBJECT,
+  properties: {
+    selfVector: {
+      type: SchemaType.OBJECT,
+      properties: {
+        o: { type: SchemaType.NUMBER },
+        c: { type: SchemaType.NUMBER },
+        e: { type: SchemaType.NUMBER },
+        a: { type: SchemaType.NUMBER },
+        n: { type: SchemaType.NUMBER },
+      },
+      required: ["o", "c", "e", "a", "n"],
+    },
+    personaSummary: { type: SchemaType.STRING },
+  },
+  required: ["selfVector", "personaSummary"],
+};
+
+/** 分析結果の Zod スキーマ（0〜1 の範囲チェック） */
+const big5Schema = z
+  .object({
+    o: z.number().min(0).max(1),
+    c: z.number().min(0).max(1),
+    e: z.number().min(0).max(1),
+    a: z.number().min(0).max(1),
+    n: z.number().min(0).max(1),
+  })
+  .strict();
+
+const analyzeResultSchema = z
+  .object({
+    selfVector: big5Schema,
+    personaSummary: z.string(),
+  })
+  .strict();
+
+export type AnalyzeResult = {
+  selfVector: Big5Vector;
+  personaSummary: string;
+};
+
+/**
+ * 会話ログを渡し、Gemini で Big5 と要約を推定して返す。
+ * 検証失敗時はリトライ（最大 MAX_RETRIES 回）、それでも失敗ならエラーを投げる。
+ */
+export async function analyzeFromMessages(
+  messages: AnalyzeMessage[]
+): Promise<AnalyzeResult> {
+  const client = getGeminiClient();
+  const model = client.getGenerativeModel({
+    model: GEMINI_MODEL_NAME,
+    generationConfig: {
+      responseMimeType: "application/json",
+      responseSchema: analyzeResponseSchema,
+    },
+  });
+
+  const prompt = buildAnalyzePrompt(messages);
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const result = await model.generateContent(prompt);
+      const text =
+        result.response.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+      if (!text) {
+        throw new Error("Empty response from Gemini");
+      }
+      const parsed = JSON.parse(text) as unknown;
+      const validated = analyzeResultSchema.parse(parsed);
+      return {
+        selfVector: validated.selfVector,
+        personaSummary: validated.personaSummary,
+      };
+    } catch (err) {
+      lastError = err;
+      if (attempt === MAX_RETRIES) break;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(String(lastError));
+}

--- a/lib/prompts/analyze.ts
+++ b/lib/prompts/analyze.ts
@@ -1,0 +1,56 @@
+/**
+ * 会話ログから Big5（selfVector）と要約（personaSummary）を導くプロンプト
+ * issue: ai_prompts（big5要約のプロンプトテンプレート）
+ */
+
+export type AnalyzeMessage = {
+  role: "user" | "model";
+  content: string;
+};
+
+/** 分析用の指示文（JSON のみ出力するよう明示） */
+const ANALYZE_INSTRUCTION = `あなたは、会話履歴から話し手（ユーザー）の性格を分析する役割です。
+
+## やること
+- 会話履歴から、**ユーザー**（user）の発言や振る舞いをもとに、Big5 性格特性を推定する。
+  - **o** (Openness: 開放性) 0〜1
+  - **c** (Conscientiousness: 誠実性) 0〜1
+  - **e** (Extraversion: 外向性) 0〜1
+  - **a** (Agreeableness: 協調性) 0〜1
+  - **n** (Neuroticism: 神経症傾向) 0〜1
+- その会話で見えた「その人の顔」を、**一文・100字以内**で要約する（personaSummary）。
+
+## 出力形式
+以下の JSON のみを出力してください。説明・markdown・コードブロック・余計な文言は一切付けないでください。
+
+{"selfVector":{"o":0.0,"c":0.0,"e":0.0,"a":0.0,"n":0.0},"personaSummary":""}`;
+
+/**
+ * 会話ログをプロンプト用のテキストに整形する
+ */
+function formatMessages(messages: AnalyzeMessage[]): string {
+  return messages
+    .map((m) => {
+      const label = m.role === "user" ? "ユーザー" : "AI";
+      return `【${label}】\n${m.content}`;
+    })
+    .join("\n\n");
+}
+
+/**
+ * 会話ログを受け取り、分析用のプロンプト（ユーザー向けテキスト）を組み立てる
+ */
+export function buildAnalyzePrompt(messages: AnalyzeMessage[]): string {
+  const conversation = formatMessages(messages);
+  return `${ANALYZE_INSTRUCTION}
+
+---
+
+## 会話履歴
+
+${conversation}
+
+---
+
+上記の会話から、ユーザーの selfVector と personaSummary を推定し、指定の JSON 形式のみを出力してください。`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "amiro",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/ssr": "^0.8.0",
-        "@supabase/supabase-js": "^2.95.3",
         "@google/generative-ai": "^0.24.1",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
@@ -20,7 +18,8 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -4372,98 +4371,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@supabase/auth-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
-      "integrity": "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/functions-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.3.tgz",
-      "integrity": "sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/postgrest-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.3.tgz",
-      "integrity": "sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/realtime-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.3.tgz",
-      "integrity": "sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "tslib": "2.8.1",
-        "ws": "^8.18.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/ssr": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz",
-      "integrity": "sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.2"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.76.1"
-      }
-    },
-    "node_modules/@supabase/storage-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.3.tgz",
-      "integrity": "sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==",
-      "license": "MIT",
-      "dependencies": {
-        "iceberg-js": "^0.8.1",
-        "tslib": "2.8.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@supabase/supabase-js": {
-      "version": "2.95.3",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
-      "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-js": "2.95.3",
-        "@supabase/functions-js": "2.95.3",
-        "@supabase/postgrest-js": "2.95.3",
-        "@supabase/realtime-js": "2.95.3",
-        "@supabase/storage-js": "2.95.3"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -6437,12 +6344,6 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
@@ -13301,7 +13202,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@supabase/ssr": "^0.8.0",
-    "@supabase/supabase-js": "^2.95.3",
     "@google/generative-ai": "^0.24.1",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
@@ -23,7 +21,8 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## 概要
会話ログから Big5（selfVector）と要約（personaSummary）を返す API を実装しました。

## 変更内容
- **lib/prompts/analyze.ts** … 分析用プロンプトテンプレートと `buildAnalyzePrompt`
- **lib/ai/analyze.ts** … Gemini 呼び出し（JSON モード）、Zod 検証、リトライ
- **POST /api/ai/analyze** … リクエストで `messages` を受け取り、`{ selfVector, personaSummary }` を返す

## 試した結果が以下のような感じです
curl -X POST http://localhost:3000/api/ai/analyze -H "Content-Type: application/json" -d "{\"messages\":[{\"role\":\"user\",\"content\":\"今日は一人で過ごしたい\"},{\"role\":\"model\",\"content\":\"そうなんだ\"},{\"role\":\"user\",\"content\":\"うん、静かにいたい\"}]}"
{"selfVector":{"o":0.5,"c":0.5,"e":0.1,"a":0.5,"n":0.5},"personaSummary":"一人の 時間を好み、静かに過ごすことを望む、内向的な性格の持ち主です。"}