### PR TITLE
fix: プロフィール画面を修正、スロットの反映

### DIFF
--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,6 +1,6 @@
 // app/(app)/profile/page.tsx
 import SlotManager from '@/components/layout/SlotManager';
-import { User, Settings } from 'lucide-react';
+import { User } from 'lucide-react';
 
 export const metadata = {
   title: 'プロフィール管理 | Amiro',
@@ -9,50 +9,43 @@ export const metadata = {
 // ▼ ユーザー情報のモックデータ
 const MOCK_USER = {
   name: 'Sample User',
-  email: 'user@example.com',
-  iconUrl: null, // 画像があればURL、なければnull
+  iconUrl: null, 
 };
 
 export default function ProfilePage() {
   return (
-    // 画面固定のための高さ指定 (サイドバーやヘッダーの有無で調整が必要ですが、ここでは100vh基準で調整)
-    // h-screen からパディング等を引いて、画面内に収まるようにしています
-    <div className="h-[calc(100vh-2rem)] flex flex-col p-6 lg:p-8 overflow-hidden">
+    // 画面全体の高さを固定し、中央寄せ
+    <div className="h-[calc(100vh-1rem)] flex flex-col p-4 lg:p-8 overflow-hidden w-full max-w-5xl mx-auto">
       
-      {/* 1. ページヘッダー & ユーザー情報 */}
-      <div className="shrink-0 mb-6 flex items-end justify-between border-b border-zinc-200 pb-6">
+      {/* 1. ページヘッダー & ユーザー情報 (固定エリア) */}
+      <div className="shrink-0 mb-4 flex items-end justify-between border-b border-zinc-200 pb-4">
         <div>
           <h1 className="text-2xl font-extrabold text-zinc-900 tracking-tight">プロフィール</h1>
           <p className="text-xs text-zinc-500 mt-1">
             アカウント情報とマッチングスロットの管理
           </p>
           
-          {/* ユーザー情報 (New) */}
-          <div className="flex items-center gap-3 mt-4">
-            <div className="w-12 h-12 bg-zinc-100 border border-zinc-200 rounded-full flex items-center justify-center text-zinc-500 shadow-sm overflow-hidden">
+          <div className="flex items-center gap-3 mt-3">
+            <div className="w-10 h-10 bg-zinc-100 border border-zinc-200 rounded-full flex items-center justify-center text-zinc-500 shadow-sm overflow-hidden">
               {MOCK_USER.iconUrl ? (
                 <img src={MOCK_USER.iconUrl} alt={MOCK_USER.name} className="w-full h-full object-cover" />
               ) : (
-                <User strokeWidth={1.5} size={24} />
+                <User strokeWidth={1.5} size={20} />
               )}
             </div>
             <div>
-              <p className="text-lg font-bold text-zinc-900 leading-none">{MOCK_USER.name}</p>
-              <p className="text-xs text-zinc-400 font-mono mt-0.5">{MOCK_USER.email}</p>
+              <p className="text-base font-bold text-zinc-900 leading-none">{MOCK_USER.name}</p>
             </div>
           </div>
         </div>
-
-        {/* 設定ボタン (飾り) */}
-        <button className="text-zinc-400 hover:text-zinc-600 p-2 hover:bg-zinc-100 rounded-full transition-colors">
-          <Settings size={20} />
-        </button>
       </div>
 
-      {/* 2. スロット管理エリア (残り高さいっぱいを使う) */}
-      <div className="flex-1 min-h-0 bg-zinc-50 rounded-3xl border border-zinc-200 p-6 shadow-inner overflow-hidden">
-        {/* コンポーネント自体で高さ調整を行っているため、ここでは配置のみ */}
-        <SlotManager />
+      {/* 2. スクロール領域ラッパー */}
+      <div className="flex-1 overflow-y-auto min-h-0 w-full rounded-3xl">
+        {/* 背景色付きのコンテナ: h-fit で中身に合わせる */}
+        <div className="bg-zinc-50 rounded-3xl border border-zinc-200 p-4 lg:p-6 shadow-inner h-fit min-h-min w-full">
+          <SlotManager />
+        </div>
       </div>
       
     </div>

--- a/components/layout/SlotManager.tsx
+++ b/components/layout/SlotManager.tsx
@@ -7,7 +7,6 @@ import { User, Trash2, RefreshCw, Plus } from 'lucide-react';
 
 const MAX_SLOTS = 3;
 
-// 詳細ページと統一したマッピング定義
 const TRAIT_MAPPING = [
   { 
     key: 'e', label: '外向性', leftLabel: '内向', rightLabel: '外向',
@@ -100,42 +99,41 @@ export default function SlotManager() {
   const activeSlotCount = Object.values(slots).filter(slot => slot !== null).length;
 
   return (
-    <div className="flex flex-col h-full gap-6">
+    <div className="flex flex-col gap-4 w-full">
       
       {/* ヘッダーエリア */}
-      <div className="flex justify-between items-center px-2 shrink-0 border-b border-zinc-200 pb-4">
-        <h3 className="text-lg font-bold text-zinc-800 flex items-center gap-3">
-          スロット一覧
-          <span className="text-xs font-normal text-zinc-500 bg-zinc-100 px-3 py-1 rounded-full border border-zinc-200">
-            {activeSlotCount} / {MAX_SLOTS} 使用中
+      <div className="flex justify-between items-center px-1 shrink-0">
+        <h3 className="text-base font-bold text-zinc-700 flex items-center gap-2">
+          マッチングスロット設定
+          <span className="text-xs font-normal text-zinc-500 bg-zinc-100 px-2 py-0.5 rounded-full border border-zinc-200">
+            {activeSlotCount} / {MAX_SLOTS}
           </span>
         </h3>
         <button 
           onClick={fetchSlots} 
           disabled={isLoading}
-          className="text-zinc-400 hover:text-zinc-700 transition-colors p-2 rounded-full hover:bg-zinc-100"
+          className="text-zinc-400 hover:text-zinc-700 transition-colors p-1.5 rounded-full hover:bg-zinc-100"
           title="データを再取得"
         >
-          <RefreshCw size={18} className={isLoading ? "animate-spin" : ""} />
+          <RefreshCw size={16} className={isLoading ? "animate-spin" : ""} />
         </button>
       </div>
 
-      {/* スロットグリッド (カードサイズを自然に戻す) */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6 overflow-y-auto pb-10">
+      {/* スロットグリッド (h-full等を削除し、内容に合わせて伸縮) */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
         {[1, 2, 3].map((index) => {
           const slot = slots[index];
 
           // --- ケースA: データなし ---
           if (!slot) {
             return (
-              <div key={index} className="border-2 border-dashed border-zinc-200 rounded-2xl p-6 flex flex-col items-center justify-center min-h-[400px] bg-zinc-50/30 text-zinc-400 transition-colors hover:bg-zinc-50/60">
-                <div className="w-16 h-16 rounded-full bg-zinc-100 flex items-center justify-center mb-4">
-                  <Plus size={24} className="text-zinc-300" />
+              <div key={index} className="border-2 border-dashed border-zinc-200 rounded-2xl p-6 flex flex-col items-center justify-center bg-zinc-50/30 text-zinc-400 transition-colors hover:bg-zinc-50/60 min-h-[320px]">
+                <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center mb-3">
+                  <Plus size={20} className="text-zinc-300" />
                 </div>
                 <p className="text-sm font-bold text-zinc-500">Slot {index}</p>
-                <p className="text-xs mt-2 text-center text-zinc-400">
-                  未設定 (Empty)<br/>
-                  <span className="opacity-70">チャット分析後に生成されます</span>
+                <p className="text-xs mt-1 text-center text-zinc-400">
+                  未設定
                 </p>
               </div>
             );
@@ -143,43 +141,44 @@ export default function SlotManager() {
           
           // --- ケースB: データあり ---
           return (
-            <div key={index} className="relative border border-zinc-200 rounded-2xl p-5 shadow-sm bg-white flex flex-col min-h-[480px] hover:shadow-md transition-shadow group">
+            <div key={index} className="relative border border-zinc-200 rounded-2xl p-4 shadow-sm bg-white flex flex-col hover:shadow-md transition-shadow group">
               
-              {/* スロット番号バッジ */}
-              <div className="absolute top-4 left-4 bg-zinc-900 text-white text-[10px] font-bold px-2 py-0.5 rounded-full shadow-sm z-10">
-                Slot {index}
+              {/* スロット番号 & 日付 */}
+              <div className="flex justify-between items-center mb-3">
+                <span className="bg-zinc-900 text-white text-[9px] font-bold px-2 py-0.5 rounded-full">
+                  Slot {index}
+                </span>
+                <span className="text-[9px] text-zinc-300 font-mono">
+                  {new Date(slot.createdAt).toLocaleDateString('ja-JP')}
+                </span>
               </div>
 
               {/* アイコン */}
-              <div className="flex justify-center mt-2 mb-5 shrink-0">
-                <div className="w-16 h-16 bg-zinc-50 border border-zinc-100 rounded-full flex items-center justify-center text-zinc-500 shadow-sm group-hover:scale-105 transition-transform">
-                  <User strokeWidth={1.5} size={32} />
+              <div className="flex justify-center mb-3">
+                <div className="w-12 h-12 bg-zinc-50 border border-zinc-100 rounded-full flex items-center justify-center text-zinc-500 shadow-sm group-hover:scale-105 transition-transform">
+                  <User strokeWidth={1.5} size={24} />
                 </div>
               </div>
 
               {/* ベクトル情報 (2カラム) */}
-              <div className="grid grid-cols-2 gap-x-6 gap-y-4 mb-5 px-1">
-                
+              <div className="grid grid-cols-2 gap-x-3 gap-y-4 mb-4">
                 {/* 左: 自己ベクトル */}
                 <div>
-                  <p className="text-[10px] font-bold text-zinc-500 text-center border-b border-zinc-100 pb-1.5 mb-3 tracking-wider">
+                  <p className="text-[9px] font-bold text-zinc-500 text-center border-b border-zinc-100 pb-1 mb-2 tracking-wider">
                     自己 (Real)
                   </p>
-                  <div className="space-y-3">
+                  <div className="space-y-2.5">
                     {TRAIT_MAPPING.map((trait) => {
                       const val = (slot.selfVector[trait.key] ?? 0.5) * 100;
                       return (
-                        <div key={`self-${trait.key}`} className="relative h-4">
-                          {/* ラベル行 */}
-                          <div className="relative flex justify-between items-end mb-1 px-1 h-3">
-                            <span className="text-[8px] text-zinc-400 font-medium">{trait.leftLabel}</span>
-                            <span className="absolute left-1/2 -translate-x-1/2 bottom-0 text-[9px] font-bold text-zinc-600">{trait.label}</span>
-                            <span className="text-[8px] text-zinc-400 font-medium">{trait.rightLabel}</span>
+                        <div key={`self-${trait.key}`} className="relative h-3">
+                          <div className="relative flex justify-between items-end mb-0.5 px-0.5 h-2.5">
+                            <span className="text-[8px] text-zinc-400 scale-90 origin-left">{trait.leftLabel}</span>
+                            <span className="absolute left-1/2 -translate-x-1/2 bottom-0 text-[8px] font-bold text-zinc-600 scale-90">{trait.label}</span>
+                            <span className="text-[8px] text-zinc-400 scale-90 origin-right">{trait.rightLabel}</span>
                           </div>
-                          {/* プロット線 */}
-                          <div className={`h-1.5 w-full rounded-full relative ${trait.barColor}`}>
+                          <div className={`h-1 w-full rounded-full relative ${trait.barColor}`}>
                              <div className="absolute top-1/2 -translate-y-1/2 w-full h-px bg-zinc-300/40"></div>
-                             {/* ドット (w-2 h-2) */}
                              <div 
                                className={`absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full border shadow-sm ${trait.color}`}
                                style={{ left: `calc(${val}% - 4px)` }}
@@ -193,24 +192,21 @@ export default function SlotManager() {
 
                 {/* 右: 共鳴ベクトル */}
                 <div>
-                  <p className="text-[10px] font-bold text-rose-400 text-center border-b border-rose-50 pb-1.5 mb-3 tracking-wider">
+                  <p className="text-[9px] font-bold text-rose-400 text-center border-b border-rose-50 pb-1 mb-2 tracking-wider">
                     共鳴 (Ideal)
                   </p>
-                  <div className="space-y-3">
+                  <div className="space-y-2.5">
                     {TRAIT_MAPPING.map((trait) => {
                       const val = (slot.resonanceVector[trait.key] ?? 0.5) * 100;
                       return (
-                        <div key={`res-${trait.key}`} className="relative h-4">
-                          {/* ラベル行 */}
-                          <div className="relative flex justify-between items-end mb-1 px-1 h-3">
-                            <span className="text-[8px] text-zinc-400 font-medium">{trait.leftLabel}</span>
-                            <span className="absolute left-1/2 -translate-x-1/2 bottom-0 text-[9px] font-bold text-zinc-600">{trait.label}</span>
-                            <span className="text-[8px] text-zinc-400 font-medium">{trait.rightLabel}</span>
+                        <div key={`res-${trait.key}`} className="relative h-3">
+                          <div className="relative flex justify-between items-end mb-0.5 px-0.5 h-2.5">
+                            <span className="text-[8px] text-zinc-400 scale-90 origin-left">{trait.leftLabel}</span>
+                            <span className="absolute left-1/2 -translate-x-1/2 bottom-0 text-[8px] font-bold text-zinc-600 scale-90">{trait.label}</span>
+                            <span className="text-[8px] text-zinc-400 scale-90 origin-right">{trait.rightLabel}</span>
                           </div>
-                          {/* プロット線 */}
-                          <div className={`h-1.5 w-full rounded-full relative ${trait.barColor}`}>
+                          <div className={`h-1 w-full rounded-full relative ${trait.barColor}`}>
                              <div className="absolute top-1/2 -translate-y-1/2 w-full h-px bg-zinc-300/40"></div>
-                             {/* ドット (w-2 h-2) */}
                              <div 
                                className={`absolute top-1/2 -translate-y-1/2 w-2 h-2 rounded-full border shadow-sm ${trait.color}`}
                                style={{ left: `calc(${val}% - 4px)` }}
@@ -223,28 +219,25 @@ export default function SlotManager() {
                 </div>
               </div>
 
-              {/* 分人要約文 (適度な高さに) */}
-              <div className="mb-4">
-                <div className="bg-zinc-50 rounded-xl p-3 border border-zinc-100 min-h-[80px]">
-                  <p className="text-[10px] font-bold text-zinc-400 mb-1 uppercase tracking-wider">分人要約</p>
-                  <p className="text-xs text-zinc-700 leading-relaxed line-clamp-3">
+              {/* 分人要約文 */}
+              <div className="mb-4 flex-grow">
+                <div className="bg-zinc-50 rounded-xl p-2.5 border border-zinc-100">
+                  <p className="text-[9px] font-bold text-zinc-400 mb-0.5">分人要約</p>
+                  <p className="text-[10px] text-zinc-700 leading-relaxed line-clamp-3">
                     {slot.personaSummary}
                   </p>
                 </div>
               </div>
               
               {/* フッター */}
-              <div className="pt-3 border-t border-zinc-100 mt-auto flex justify-between items-center">
-                <span className="text-[10px] text-zinc-400 font-mono pl-1">
-                  Updated: {new Date(slot.createdAt).toLocaleDateString('ja-JP')}
-                </span>
+              <div className="pt-2 border-t border-zinc-100 mt-auto flex justify-end">
                 <button 
                   onClick={() => handleDeleteSlot(index)}
                   disabled={isLoading}
-                  className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
+                  className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors disabled:opacity-50"
                   title="削除"
                 >
-                  <Trash2 size={14} />
+                  <Trash2 size={12} />
                   削除
                 </button>
               </div>
@@ -252,7 +245,7 @@ export default function SlotManager() {
               {isLoading && (
                 <div className="absolute inset-0 bg-white/70 backdrop-blur-[1px] z-20 flex items-center justify-center rounded-2xl">
                   <div className="animate-spin text-zinc-400">
-                    <RefreshCw size={24} />
+                    <RefreshCw size={20} />
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## 関連Issue
Close #31

## 概要
ユーザーのプロフィール情報を表示し、マッチングに使用される「分人（ペルソナ）スロット」を管理する機能を実装しました。
スロットの表示デザインを共鳴マッチング機能（`MatchingDetail`）と統一し、視認性と操作性を向上させました。

## 主な変更点

### 1. プロフィールページ (`app/(app)/profile/page.tsx`)
* **レイアウト刷新**: 画面全体の高さを固定し、不要なスクロールが発生しないダッシュボードライクなUIに変更。
* **ユーザー情報**: ヘッダー部分にユーザーアイコンと名前を表示（現在はモックデータ）。
* **項目整理**: 未実装だった「基本情報」セクションを削除し、スロット管理にフォーカス。

### 2. スロット管理コンポーネント (`components/layout/SlotManager.tsx`)
* **データ連携 (Mock)**:
  * データベース未実装のため、クライアントサイドで完結するモックデータ (`MOCK_DB_DATA`) を導入。
  * `fetch` (取得) および `delete` (削除) の非同期処理をシミュレートし、ローディング状態 (`isLoading`) を実装。
* **UIデザイン統一**:
  * ベクトルチャートを「バーグラフ」から、共鳴詳細ページと同じ「線分上の点プロット」形式に変更。
  * 項目名（外向性・協調性など）や左右のラベル（内向⇔外向など）、配色をプロジェクト全体で統一。
* **機能変更**:
  * 手動での「スロット追加」ボタンを削除（チャット分析により自動生成される仕様に準拠）。
  * 各スロットカードに「削除」ボタンを設置。
  * 空きスロットの表示状態（Empty State）を実装。

## UI/UXのこだわり
* **視覚的な一貫性**: マッチング画面とプロフィール画面で、ベクトルの見方（濃い色が自己、薄い色が共鳴など ※今回は自己・共鳴を並列表示）に違和感がないように調整しました。
* **インタラクション**: データの再取得や削除時にスピナーを表示し、処理中であることをユーザーに伝わりやすくしました。
* **レスポンシブ対応**: グリッドレイアウトを採用し、画面幅に応じてカードの並びが最適化されるようにしました。

## 確認手順
1. `/profile` にアクセスする。
2. ヘッダーにユーザー情報（アイコン・名前）が表示されていることを確認。
3. スロット一覧が表示され、ベクトルチャートが「点プロット」形式で描画されていることを確認。
4. 「削除」ボタンをクリックし、確認ダイアログを経てデータが消える（モック上で）ことを確認。
5. 右上の更新ボタンを押して、ロード表示が出ることを確認。

## 備考
* 現在のデータはすべてフロントエンド内のモックです。バックエンドAPI実装後に差し替えが必要です。