### PR TITLE
feat: haku-マッチングAPIにbioと分人要約を返す

### DIFF
--- a/app/api/matching/route.ts
+++ b/app/api/matching/route.ts
@@ -29,7 +29,7 @@ type RpcRow = {
 /**
  * 認証ユーザーと共鳴スコアの高い他ユーザーを取得する。RPC get_matching_scores の結果にプロフィールを結合して返す。
  * @param request - URL query: `limit` (optional, default 20, max 100), `offset` (optional, default 0). Auth required.
- * @returns 200: `MatchingResult[]` (userId, displayName, avatarUrl, resonanceScore, matchedSlotIndexSelf, matchedSlotIndexOther). 401: `{ error: "Unauthorized" }`. 503: `{ error: "Matching scores unavailable" }`. 500: `{ error: "Profiles fetch failed" }` or `{ error: "Internal server error" }`.
+ * @returns 200: `MatchingResult[]` (userId, displayName, avatarUrl, bio, resonanceScore, matchedSlotIndexSelf, matchedSlotIndexOther, personaSummary). 401: `{ error: "Unauthorized" }`. 503: `{ error: "Matching scores unavailable" }`. 500: `{ error: "Profiles fetch failed" }`, `{ error: "Slots fetch failed" }` or `{ error: "Internal server error" }`.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
     const userIds = list.map((r) => r.other_user_id);
     const { data: profiles, error: profilesError } = await supabase
       .from("profiles")
-      .select("user_id, display_name, avatar_url")
+      .select("user_id, display_name, avatar_url, bio")
       .in("user_id", userIds);
 
     if (profilesError) {
@@ -78,25 +78,49 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const { data: slotRows, error: slotsError } = await supabase
+      .from("slots")
+      .select("user_id, slot_index, persona_summary")
+      .in("user_id", userIds);
+
+    if (slotsError) {
+      return NextResponse.json(
+        { error: "Slots fetch failed" },
+        { status: 500 }
+      );
+    }
+
+    const slotSummaryMap = new Map<string, string>(
+      (slotRows ?? []).map((s) => [
+        `${s.user_id}:${s.slot_index}`,
+        s.persona_summary ?? "",
+      ])
+    );
+
     const profileMap = new Map(
       (profiles ?? []).map((p) => [
         p.user_id,
         {
           displayName: p.display_name ?? "",
           avatarUrl: p.avatar_url ?? null,
+          bio: p.bio ?? null,
         },
       ])
     );
 
     const body: MatchingResult[] = list.map((r) => {
       const p = profileMap.get(r.other_user_id);
+      const personaSummary =
+        slotSummaryMap.get(`${r.other_user_id}:${r.matched_slot_index_other}`) ?? "";
       return {
         userId: r.other_user_id,
         displayName: p?.displayName ?? "",
         avatarUrl: p?.avatarUrl ?? null,
+        bio: p?.bio ?? null,
         resonanceScore: r.resonance_score,
         matchedSlotIndexSelf: r.matched_slot_index_self,
         matchedSlotIndexOther: r.matched_slot_index_other,
+        personaSummary,
       };
     });
 

--- a/docs/amiro_仕様書.md
+++ b/docs/amiro_仕様書.md
@@ -167,13 +167,15 @@
   "userId": "uuid",
   "displayName": "string",
   "avatarUrl": "string | null",
+  "bio": "string | null",
   "resonanceScore": 0.92,
   "matchedSlotIndexSelf": 2,
-  "matchedSlotIndexOther": 1
+  "matchedSlotIndexOther": 1,
+  "personaSummary": "string"
 }
 ```
 
-`resonanceScore` は 0〜1。相互共鳴スコア（自分→相手の類似度と相手→自分の類似度の両方を考慮した値。例: 両方向の最大類似度の積や最小値）。`matchedSlotIndexSelf` / `matchedSlotIndexOther` はそのスコアを実現したスロット番号。
+`resonanceScore` は 0〜1。相互共鳴スコア（自分→相手の類似度と相手→自分の類似度の両方を考慮した値。例: 両方向の最大類似度の積や最小値）。`matchedSlotIndexSelf` / `matchedSlotIndexOther` はそのスコアを実現したスロット番号。`bio` は相手の自己紹介文（profiles）、`personaSummary` は相手のそのスロットの分人要約文。
 
 ### 5.5 共鳴詳細（AI解説）
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,7 +33,9 @@ export type MatchingResult = {
   userId: string;
   displayName: string;
   avatarUrl: string | null;
+  bio: string | null;
   resonanceScore: number;
   matchedSlotIndexSelf: number;
   matchedSlotIndexOther: number;
+  personaSummary: string;
 };

--- a/tests/api/matching/get.test.ts
+++ b/tests/api/matching/get.test.ts
@@ -56,6 +56,23 @@ vi.mock("@/lib/supabase/server", () => ({
                   user_id: "other-uuid-1",
                   display_name: "Other User",
                   avatar_url: "https://example.com/other.png",
+                  bio: "自己紹介文です",
+                },
+              ],
+              error: null,
+            }),
+          };
+        }
+        if (table === "slots") {
+          stepLog("5. slots 取得");
+          return {
+            select: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  user_id: "other-uuid-1",
+                  slot_index: 1,
+                  persona_summary: "相手の分人要約文",
                 },
               ],
               error: null,
@@ -142,9 +159,11 @@ describe("GET /api/matching", () => {
     expect(json[0].userId).toBe("other-uuid-1");
     expect(json[0].displayName).toBe("Other User");
     expect(json[0].avatarUrl).toBe("https://example.com/other.png");
+    expect(json[0].bio).toBe("自己紹介文です");
     expect(json[0].resonanceScore).toBe(0.92);
     expect(json[0].matchedSlotIndexSelf).toBe(2);
     expect(json[0].matchedSlotIndexOther).toBe(1);
+    expect(json[0].personaSummary).toBe("相手の分人要約文");
   });
 
   it("passes limit and offset from query to RPC", async () => {


### PR DESCRIPTION
## 概要
GET /api/matching のレスポンスに、相手の自己紹介文（bio）とマッチしたスロットの分人要約文（personaSummary）を追加した。

## 変更内容
- **型**: `MatchingResult` に `bio: string | null` と `personaSummary: string` を追加
- **API**: profiles から `bio` を select、slots から該当スロットの `persona_summary` を取得して返却
- **仕様書**: 5.4 MatchingResult に上記フィールドを記載
- **テスト**: モックに bio / slots を追加し、期待値を更新

## 確認してほしいこと
- [ ] GET /api/matching の各要素に `bio` と `personaSummary` が含まれること（profiles.bio がある場合）
