### PR TITLE
fix:チャット欄ヘッダーのレイアウトを改善

### DIFF
--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -208,21 +208,29 @@ export default function ChatPage() {
             </div>
           </div>
           
+          <div className="absolute left-1/2 transform -translate-x-1/2 hidden md:flex flex-col items-center">
+             <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Turn</span>
+             <p className={`font-mono text-xl font-bold leading-none ${turnCount >= MAX_TURNS ? "text-destructive" : ""}`}>
+               {turnCount} <span className="text-sm font-normal text-muted-foreground">/ {MAX_TURNS}</span>
+             </p>
+          </div>
+
           <div className="flex items-center gap-4">
-            <div className="text-right">
-              <span className="text-xs text-muted-foreground">Turn</span>
-              <p className={`font-mono font-bold ${turnCount >= MAX_TURNS ? "text-destructive" : ""}`}>
-                {turnCount} / {MAX_TURNS}
+            {/* Mobile用 Turn Count (Right aligned when button is hidden or just on right) */}
+            <div className="md:hidden flex flex-col items-end gap-0.5">
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">Turn</span>
+              <p className={`font-mono text-lg font-bold leading-none ${turnCount >= MAX_TURNS ? "text-destructive" : ""}`}>
+                {turnCount} <span className="text-sm font-normal text-muted-foreground">/ {MAX_TURNS}</span>
               </p>
             </div>
-            
+
             {/* 任意終了ボタン */}
             <Button 
               variant="outline" 
               size="sm" 
               onClick={handleFinish}
               disabled={analyzing || messages.length === 0}
-              className="hidden sm:flex"
+              className="hidden sm:flex border-primary/20 hover:bg-primary/5"
             >
               {analyzing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <LogOut className="mr-2 h-4 w-4" />}
               終了して分析


### PR DESCRIPTION
close #75 

## 概要
チャット画面 (`app/(app)/chat/page.tsx`) のヘッダーレイアウトを改善しました。
右側の「ターン数」と「終了ボタン」が窮屈だったため、配置とスタイルを見直しました。

## 変更点
- **レイアウト変更 (PC)**:
    - ターン数表示 (`Turn 0 / 10`) をヘッダー中央に配置しました（絶対配置 `absolute left-1/2`）。
    - これにより、左右のバランスが良くなり、要素間の余白が確保されました。
- **レイアウト変更 (SP)**:
    - モバイルではボタンが非表示になるため、ターン数はこれまで通り右側に配置しています。
- **デザイン調整**:
    - ターン数のフォントサイズを大きくし、"Turn" ラベルを小さくすることで視認性を向上させました。
    - 「終了して分析」ボタンのボーダー色とホバー時のスタイルを微調整しました。

## 動作確認
- [x] PC画面で、ターン数がヘッダー中央に表示されること。
- [x] PC画面で、右端の「終了して分析」ボタンとの重なりがないこと。