### PR TITLE
feat: haku-ログアウト用Server Actionを追加

### DIFF
--- a/app/(auth)/login/actions.ts
+++ b/app/(auth)/login/actions.ts
@@ -64,3 +64,20 @@ export async function signup(formData: FormData) {
   revalidatePath('/', 'layout');
   redirect('/');
 }
+
+export async function logout() {
+  const cookieStore = await cookies();
+
+  if (cookieStore.get('amiro-test-session')?.value === 'true') {
+    cookieStore.delete('amiro-test-session');
+    revalidatePath('/', 'layout');
+    redirect('/login');
+    return;
+  }
+
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+
+  revalidatePath('/', 'layout');
+  redirect('/login');
+}


### PR DESCRIPTION
## 概要
#103 のバックエンド対応。ログアウト用の Server Action `logout()` を `app/(auth)/login/actions.ts` に追加した。

## 変更内容
- `logout()`: テスト用クッキー時は削除、通常時は `supabase.auth.signOut()` のあと `/login` へリダイレクト

## テスト方法
1. **通常ログイン（Supabase）でログアウト**
   - メール/パスワードでログインする
   - ログアウトを実行するUI（#104 実装後は設定ページのボタン等）から `logout()` を呼ぶ。開発時は一時的にログイン済みページに `<form action={logout}><button type="submit">ログアウト</button></form>` を置いて試す
   - `/login` にリダイレクトされ、未ログイン扱いになることを確認する
2. **テスト用アカウント（admin / pass）でログアウト**
   - ログイン画面で email: `admin`、password: `pass` でログインする
   - 上記と同様に `logout()` を実行する
   - `/login` にリダイレクトされ、再度保護ページにアクセスすると `/login` に飛ぶことを確認する

## 関連Issue
close #103
