### PR TITLE
fix: haku-レポートページのスロット選択UIが横に飛び出してしまう問題を修正

### DIFF
--- a/app/(app)/report/page.tsx
+++ b/app/(app)/report/page.tsx
@@ -185,36 +185,54 @@ export default function ReportPage() {
               onValueChange={(val) => setSelectedSlotIndex(parseInt(val))}
               className="grid gap-3"
             >
-              {existingSlots.map((slot) => (
-                <div key={slot.slotIndex}>
-                  <RadioGroupItem
-                    value={slot.slotIndex.toString()}
-                    id={`slot-${slot.slotIndex}`}
-                    className="peer sr-only"
-                  />
-                  <Label
-                    htmlFor={`slot-${slot.slotIndex}`}
-                    className="flex items-center justify-between rounded-md border border-muted bg-popover p-3 hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary peer-data-[state=checked]:bg-primary/5 cursor-pointer transition-all"
-                  >
-                    <div className="flex items-center gap-3 overflow-hidden">
-                      <Avatar className="h-10 w-10 border shrink-0">
+              {existingSlots.map((slot) => {
+                const isSelected = selectedSlotIndex === slot.slotIndex;
+                return (
+                  <div key={slot.slotIndex}>
+                    <RadioGroupItem
+                      value={slot.slotIndex.toString()}
+                      id={`slot-${slot.slotIndex}`}
+                      className="peer sr-only"
+                    />
+                    <Label
+                      htmlFor={`slot-${slot.slotIndex}`}
+                      className={cn(
+                        "relative flex items-center gap-3 border py-3 pl-3 pr-4 cursor-pointer overflow-hidden transition-colors duration-200",
+                        isSelected
+                          ? "rounded-none border-muted/30 bg-muted/70 hover:bg-muted/80"
+                          : "rounded-xl border-muted/20 bg-transparent hover:bg-muted/25 hover:border-muted/35"
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "absolute left-0 top-0 bottom-0 w-1 bg-foreground/80 transition-transform duration-200 ease-out origin-left",
+                          isSelected ? "scale-x-100" : "scale-x-0"
+                        )}
+                        aria-hidden
+                      />
+                      <Avatar
+                        className={cn(
+                          "h-10 w-10 shrink-0 border transition-colors relative z-10",
+                          !isSelected && "border-muted/30",
+                          isSelected && "border-foreground/25 bg-background"
+                        )}
+                      >
                         <AvatarImage src={slot.personaIcon} />
-                        <AvatarFallback>{slot.slotIndex}</AvatarFallback>
+                        <AvatarFallback className={isSelected ? "!bg-background" : undefined}>
+                          {slot.slotIndex}
+                        </AvatarFallback>
                       </Avatar>
-                      <div className="space-y-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                           <span className="text-[10px] font-mono bg-muted px-1.5 rounded text-muted-foreground">Slot {slot.slotIndex}</span>
-                           <span className="text-xs text-muted-foreground">
-                             {new Date(slot.createdAt).toLocaleDateString()}
-                           </span>
-                        </div>
-                        <div className="font-medium text-sm truncate">{slot.personaSummary}</div>
+                      <div className="space-y-1 min-w-0 flex-1 relative z-10">
+                        <span className="text-xs text-muted-foreground shrink-0 block">
+                          {new Date(slot.createdAt).toLocaleDateString()}
+                        </span>
+                        <p className={cn("font-medium text-sm break-words", isSelected ? "text-foreground" : "text-foreground/85")}>{slot.personaSummary}</p>
                       </div>
-                    </div>
-                    <RefreshCcw className="h-4 w-4 text-muted-foreground/50 peer-data-[state=checked]:text-primary shrink-0 ml-2" />
-                  </Label>
-                </div>
-              ))}
+                      <RefreshCcw className={cn("h-4 w-4 shrink-0 transition-colors relative z-10", isSelected ? "text-foreground/70" : "text-muted-foreground/35")} />
+                    </Label>
+                  </div>
+                );
+              })}
             </RadioGroup>
           )}
 


### PR DESCRIPTION
## 概要
分析結果画面（`/report`）の「この分人を保存する」カード内で、スロットが満杯時に表示する「上書きする分人を選択」のUIを改善しました。

## 変更内容

### レイアウト・オーバーフロー対応
- **横はみ出しの解消**: 分人要約文が長い場合に横にはみ出していたため、`break-words` と `min-w-0` で縦改行するように変更
- **Slot N 表示の削除**: 「Slot 1」「Slot 2」「Slot 3」のラベルを廃止し、日付と要約文のみ表示

### 選択状態のデザイン（Craft 風）
- **3状態の明確化**
  - **通常**: 薄い枠（`border-muted/20`）、背景なし、ホバーで軽い背景・枠強調
  - **ホバー**: `hover:bg-muted/25`、`hover:border-muted/35`
  - **選択中**: 左に 4px のアクセントバー、背景 `bg-muted/70`、ホバー時 `bg-muted/80`
- **左アクセントバー**: 選択時のみ表示。絶対配置の `span` で `scale-x` アニメーション（コンテンツは動かさない）
- **選択時パネル**: 角を四角に（`rounded-none`）。左バーと見た目を統一
- **未選択時パネル**: `rounded-xl` を維持

### アバター（丸）
- **縦中央揃え**: 行全体を `items-center` でアバターを縦中央に配置
- **選択時**: 枠を `border-foreground/25`、塗りを白に（`bg-background`、`AvatarFallback` は `!bg-background`）

### その他
- 選択時のパネル背景をやや暗く（`muted/50` → `muted/70`、ホバー `muted/60` → `muted/80`）
- 右端の RefreshCcw アイコンは選択時のみ濃く表示（`text-foreground/70`）

## 対象ファイル
- `app/(app)/report/page.tsx`

## 確認方法
1. ログインし、スロットを3件保存して満杯にする（未満の場合はチャット→分析→保存を3回繰り返す）
2. 開発サーバー起動後、次のURLでレポート画面を開く（スロット選択UIは満杯時のみ表示される）
   - **例（長文で改行確認）**:  
     `http://localhost:3000/report?summary=ユーザーは控えめで言葉少なだが、問いかけには受け答え、自身のささやかなこだわりは示す、穏やかなタイプ。AIの問いかけに最初は抵抗するも、独自のユーモアで少しずつ垣間見せる、内向的でガードの固い人物。`
   - ポートが異なる場合は `3000` を変更する（例: `http://localhost:3001/report?summary=...`）
3. 「この分人を保存する」でスロット3件が表示されることを確認
4. 各スロットを選択したときの左バー・背景・アバターの変化、ホバー時の見え方を確認
